### PR TITLE
Fixes/ Dark mode and layout of at-mentions in Trix editor

### DIFF
--- a/app/assets/stylesheets/light/fields/trix_editor.css
+++ b/app/assets/stylesheets/light/fields/trix_editor.css
@@ -40,6 +40,8 @@ a[href^="bullettrain://users"], a[href^="bullettrain://teams"], span.tribute-use
       display: none;
     }
     li {
+      @apply flex items-center justify-between;
+
       span {
         font-weight: normal;
       }

--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -185,6 +185,22 @@
       }
     }
 
+    .tribute-container {
+        ul {
+            @apply bg-sealBlue-300 border-sealBlue-100 !important;
+        }
+    }
+
+    .trix-dialogs {
+      @apply bg-sealBlue-300 border-sealBlue-100 !important;
+    }
+
+    .trix-content {
+      a[href^="bullettrain://"] {
+        @apply bg-sealBlue-300 color-white;
+      }
+    }
+
     /* CKEditor */
     .ck {
       --ck-color-base-background: theme('colors.sealBlue.300');

--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -186,9 +186,9 @@
     }
 
     .tribute-container {
-        ul {
-            @apply bg-sealBlue-300 border-sealBlue-100 !important;
-        }
+      ul {
+        @apply bg-sealBlue-300 border-sealBlue-100 !important;
+      }
     }
 
     .trix-dialogs {

--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -197,7 +197,7 @@
 
     .trix-content {
       a[href^="bullettrain://"] {
-        @apply bg-sealBlue-300 color-white;
+        @apply bg-sealBlue-600 text-white;
       }
     }
 


### PR DESCRIPTION
Closes
---

https://github.com/bullet-train-co/bullet_train-themes-light/issues/1

Tasks
---

- Use dark mode colors for team options shown in dropdown with at-mentions
- Remove line-wrap between the user picture and the name in same dropdown as above
- Use dark mode appropriate coloring after team is chosen from dropdown

Fixes
---

- Issue 1
  - Should use dark-mode colors
  - Should not have a line-wrap between the user picture and the name

  <img width="253" alt="team dropdown options when using @" src="https://user-images.githubusercontent.com/15196941/157522453-4d4d461c-ff0d-4191-bb3c-d05d2f47ff6a.png">

- Issue 2
  - Should use dark-mode appropriate coloring.

<img width="255" alt="team name pointing to the member url" src="https://user-images.githubusercontent.com/15196941/157592994-e9b27ce3-6cbd-4b2c-8132-b1c6e9774106.png">



