### PR TITLE
Update Tailwind deprecation

### DIFF
--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -7,7 +7,7 @@
       background-color: rgba(0, 0, 0, 0.15);
     }
 
-    @variants dark {
+    @layer components {
       .bg-dark-blue-gradient {
         &:before {
           background: linear-gradient(to bottom right, #633d7d, #2867ab 100%);

--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -7,13 +7,11 @@
       background-color: rgba(0, 0, 0, 0.15);
     }
 
-    @layer components {
-      .bg-dark-blue-gradient {
-        &:before {
-          background: linear-gradient(to bottom right, #633d7d, #2867ab 100%);
-        }
+    .bg-dark-blue-gradient {
+      &:before {
         background: linear-gradient(to bottom right, #633d7d, #2867ab 100%);
       }
+      background: linear-gradient(to bottom right, #633d7d, #2867ab 100%);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the following warning that is shown when running system tests in the starter repo after compiling the stylesheet:
```
$ NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js

warn - The `@variants` directive has been deprecated in Tailwind CSS v3.0.
warn - Use `@layer utilities` or `@layer components` instead.
warn - https://tailwindcss.com/docs/upgrade-guide#replace-variants-with-layer
```

Instead of using `@layer components`, etc., I simply deleted `@variants`. You can see I also deleted `dark` here, but it shouldn't be an issue since the style is inside this block → `@media (prefers-color-scheme: dark) { ... }`