### PR TITLE
Add :raw_body to box partial

### DIFF
--- a/app/views/themes/light/_box.html.erb
+++ b/app/views/themes/light/_box.html.erb
@@ -28,7 +28,7 @@
     <% end %>
 
     <% if body %>
-      <div class="<%= 'pt-7 pb-3 px-8 space-y-7' unless p.content_for?(:raw_body) %> ">
+      <div class="<%= "pt-7 px-8 space-y-7 #{p.content_for?(:actions) ? 'pb-3' : 'pb-7'}" unless p.content_for?(:raw_body) %>">
         <div class="space-y-4 <%= '-mt-4' unless divider %>">
           <%= body %>
         </div>

--- a/app/views/themes/light/_box.html.erb
+++ b/app/views/themes/light/_box.html.erb
@@ -3,6 +3,7 @@
 <% divider ||= nil %>
 <% no_background ||= false %>
 <% title_size ||= "text-xl" %>
+<% body = p.content_for(:body) || p.content_for(:raw_body) %>
 
 <div class="<%= "bg-white rounded-md shadow dark:bg-sealBlue-400" unless no_background %> overflow-hidden">
   <div class="py-6 px-8 space-y-2 <%= 'border-b shadow-sm dark:border-sealBlue-500' if divider %>">
@@ -26,19 +27,19 @@
       </div>
     <% end %>
 
-    <% if p.content_for?(:body) || p.content_for?(:actions) %>
-      <div class="<%= p.content_for?(:body) ? 'py-7' : 'pb-7' %> px-8 space-y-7">
-        <% if p.content_for? :body %>
-          <div class="space-y-4 <%= '-mt-4' unless divider %>">
-            <%= p.content_for :body %>
-          </div>
-        <% end %>
+    <% if body %>
+      <div class="<%= 'pt-7 pb-3 px-8 space-y-7' unless p.content_for?(:raw_body) %> ">
+        <div class="space-y-4 <%= '-mt-4' unless divider %>">
+          <%= body %>
+        </div>
+      </div>
+    <% end %>
 
-        <% if p.content_for? :actions %>
-          <div class="space-x">
-            <%= p.content_for :actions %>
-          </div>
-        <% end %>
+    <% if p.content_for? :actions %>
+      <div class="pb-7 px-8 space-y-7">
+        <div class="space-x">
+          <%= p.content_for :actions %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Allow `raw_body` to be passed to the box partial, instead of `body` for when you want to control the padding of the body from the calling template.

Addresses issue #5