### PR TITLE
Support external participants in conversations

### DIFF
--- a/app/views/themes/light/conversations/_message.html.erb
+++ b/app/views/themes/light/conversations/_message.html.erb
@@ -1,5 +1,6 @@
 <% new_message ||= false %>
-<% current_user_message = message.author == current_user %>
+<% current_author = defined?(current_user) ? current_user : send(BulletTrain::Conversations.current_participant_helper_method) %>
+<% current_user_message = message.author == current_author %>
 <% avatar = capture do %>
   <% if message.membership %>
     <img src="<%= membership_profile_photo_url(message.membership) %>" title="<%= message.user_name %>" alt="<%= message.user_name %>" class="w-6 h-6 rounded-full <%= current_user_message ? 'order-2' : 'order-1' %>">
@@ -36,7 +37,7 @@
 <% timestamp = next_message_in_series || show_as_thread ? '' : time_ago_in_words(message.created_at) + " ago" %>
 
 <% threaded_message = message.threaded? %>
-<% thread_started_by_current_user = message.thread_origin_user == current_user %>
+<% thread_started_by_current_user = message.thread_origin_user == current_author %>
 <% last_message_in_thread = !placeholder_message && threaded_message && (message.next_message.nil? || message.next_message.thread_id != message.thread_id)%>
 <% out_of_thread_message = !show_as_thread && threaded_message && message.reply? && message.previous_message != message.previous_message_in_thread %>
 <% has_replies = message.replies.any? && message.next_message == message.next_message_in_thread %>

--- a/app/views/themes/light/conversations/_message.html.erb
+++ b/app/views/themes/light/conversations/_message.html.erb
@@ -1,12 +1,20 @@
 <% new_message ||= false %>
-<% current_user_message = message.membership.user == current_user %>
+<% current_user_message = message.author == current_user %>
 <% avatar = capture do %>
-  <img src="<%= membership_profile_photo_url(message.membership) %>" title="<%= message.membership.name %>" alt="<%= message.membership.name %>" class="w-6 h-6 rounded-full <%= current_user_message ? 'order-2' : 'order-1' %>">
+  <% if message.membership %>
+    <img src="<%= membership_profile_photo_url(message.membership) %>" title="<%= message.user_name %>" alt="<%= message.user_name %>" class="w-6 h-6 rounded-full <%= current_user_message ? 'order-2' : 'order-1' %>">
+  <% elsif message.participant %>
+    <div class="<%= current_user_message ? 'order-2' : 'order-1' %>">
+      <% if BulletTrain::Conversations.respond_to?(:participant_avatar_partial) && BulletTrain::Conversations.participant_avatar_partial %>
+        <%= render BulletTrain::Conversations.participant_avatar_partial, participant: message.participant %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>
 <% next_message ||= message.next_message %>
 
 <%# A message series is a series of messages by the same user, each message within 5 minutes of the previous message.  It has nothing to do with replies and message threads %>
-<% next_message_in_series = (message.user == next_message&.user) && (message.created_at > next_message.created_at - 5.minutes) && (message.parent_message_id == next_message&.parent_message_id || message.id == next_message.parent_message_id)%>
+<% next_message_in_series = (message.author == next_message&.author) && (message.created_at > next_message.created_at - 5.minutes) && (message.parent_message_id == next_message&.parent_message_id || message.id == next_message.parent_message_id)%>
 <% if next_message_in_series %>
   <% avatar = nil %>
 <% end %>
@@ -43,7 +51,7 @@
 <div class="chat-message"
   <% unless show_as_thread %>
     data-reply-target="message"
-    data-user="<%= message.membership.label_string %>"
+    data-user="<%= message.author.label_string %>"
     data-message-id="<%= message.parent_message_id || message.id %>"
     data-action="mouseleave->reply#hideReplyButton"
   <% end %>
@@ -102,7 +110,7 @@
 
       <div class="flex flex-grow order-1 <%= current_user_message ? 'justify-end items-end pr-8' : 'justify-start items-start pl-8' %> <%= 'mb-3' unless next_message_in_series %>">
         <div class="<%= show_as_thread ? 'text-gray-400' : 'text-gray-300' %> text-sm">
-          <strong><%= message.user.name %></strong>
+          <strong><%= message.author.name %></strong>
           <%= timestamp %>
         </div>
       </div>


### PR DESCRIPTION
When a conversation has a non-membership participant, it renders their avatar as defined in the conversations configuration.