### PR TITLE
Eject mailer config to main application

### DIFF
--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -9,6 +9,9 @@ namespace :bullet_train do
         puts "Ejecting Tailwind configuration into `./tailwind.#{args[:destination]}.config.js`."
         `cp #{theme_base_path}/tailwind.light.config.js #{Rails.root}/tailwind.#{args[:destination]}.config.js`
 
+        puts "Ejecting Tailwind mailer configuration into `./tailwind.mailer.#{args[:destination]}.config.js`."
+        `cp #{theme_base_path}/tailwind.mailer.light.config.js #{Rails.root}/tailwind.mailer.#{args[:destination]}.config.js`
+
         puts "Ejecting stylesheets into `./app/assets/stylesheets/#{args[:destination]}`."
         `mkdir #{Rails.root}/app/assets/stylesheets`
         `cp -R #{theme_base_path}/app/assets/stylesheets/light #{Rails.root}/app/assets/stylesheets/#{args[:destination]}`

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -35,7 +35,7 @@ namespace :bullet_train do
 
         # Stub out the class that represents this theme and establishes its inheritance structure.
         target_path = "#{Rails.root}/app/lib/bullet_train/themes/#{args[:destination]}.rb"
-        puts "Stubbing out a class that represents this theme in `./#{target_path}`."
+        puts "Stubbing out a class that represents this theme in `.#{target_path}`."
         `mkdir -p #{Rails.root}/app/lib/bullet_train/themes`
         `cp #{theme_base_path}/lib/bullet_train/themes/light.rb #{target_path}`
         `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/module Light/module #{args[:destination].titlecase}/g" #{target_path}`

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -11,6 +11,7 @@ namespace :bullet_train do
 
         puts "Ejecting Tailwind mailer configuration into `./tailwind.mailer.#{args[:destination]}.config.js`."
         `cp #{theme_base_path}/tailwind.mailer.light.config.js #{Rails.root}/tailwind.mailer.#{args[:destination]}.config.js`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{Rails.root}/tailwind.mailer.#{args[:destination]}.config.js`
 
         puts "Ejecting stylesheets into `./app/assets/stylesheets/#{args[:destination]}`."
         `mkdir #{Rails.root}/app/assets/stylesheets`


### PR DESCRIPTION
Closes #18.

This will eject in the mailer config to the main application, which will let our tests pass.
There's only one system test that is failing, but it's related to `bin/resolve`, so I can check that out in a bit.
I also fixed a minor typo along the way.
