### PR TITLE
Fix Turn animation in Devise layout

### DIFF
--- a/app/assets/stylesheets/light/application.css
+++ b/app/assets/stylesheets/light/application.css
@@ -4,6 +4,7 @@
 @import "./tailwind/colors";
 
 @import "./electron";
+@import './devise';
 @import './fields';
 @import './turn';
 

--- a/app/assets/stylesheets/light/devise.css
+++ b/app/assets/stylesheets/light/devise.css
@@ -1,0 +1,15 @@
+/*
+ * This takes care of the window's contents shifting when the
+ * scrollbar appears and disappears during the turn.css animation
+ */
+
+/* Chrome, Safari and Opera */
+.devise_layout::-webkit-scrollbar {
+  display: none;
+}
+
+/* Firefox and Edge */
+.devise_layout {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/app/views/themes/light/layouts/_devise.html.erb
+++ b/app/views/themes/light/layouts/_devise.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render 'shared/layouts/head' %>
   </head>
-  <body class="bg-light-gradient text-gray-700 text-sm font-normal electron-draggable dark:bg-dark-gradient dark:text-darkPrimary-300">
+  <body class="devise_layout bg-light-gradient text-gray-700 text-sm font-normal electron-draggable dark:bg-dark-gradient dark:text-darkPrimary-300">
     <div data-turn-enter data-turn-exit>
       <%= yield %>
     </div>


### PR DESCRIPTION
I really like the new turn animation (awesome job @jorbs :tada:), but I noticed the scrollbar will appear and disappear during the animation when working on a smaller screen, causing the content to jump sideways. The videos here are a little laggy, but you can see how the content jumps when the animation finishes.

I figured we shouldn't hide the scrollbar for the entire application (as you can see in the second video), but I personally would rather go with this aesthetic trade-off for the devise views if it means the contents won't skip. We'd have to consider another fix if we want to allow developers to use turn anywhere else where the content shifting might be an issue.

If anyone has a better way of handling this, I'm open to ideas.

# Before
https://user-images.githubusercontent.com/10546292/175485597-d6c045e8-93e4-4470-9978-5cfa4d6ac1f0.mp4

# After
https://user-images.githubusercontent.com/10546292/175485543-91e25caf-8ddd-4415-abde-55b60c7ee98c.mp4
