### PR TITLE
Fix mobile menu breaking after repeated reveal/hide: Change to simpler mobile_menu controller

### DIFF
--- a/app/views/themes/light/layouts/_account.html.erb
+++ b/app/views/themes/light/layouts/_account.html.erb
@@ -19,6 +19,7 @@
 
             <div class="lg:hidden absolute right-0">
               <button class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white dark:ring-transparent"
+                id="mobile-menu-close"
                 data-action="reveal#hide"
               >
                 <span class="sr-only">Close Application Menu</span>
@@ -56,6 +57,7 @@
 
         <div class="lg:hidden hidden"
           data-mobile-menu-target="wrapper"
+          id="mobile-menu-backdrop"
 
           data-controller="reveal"
           data-reveal-away-value="true"
@@ -110,6 +112,7 @@
           <main class="flex-1 relative z-0 focus:outline-none" tabindex="0">
             <div class="flex flex-row items-center shadow-sm electron-draggable">
               <button class="mobile-menu-trigger lg:hidden h-12 w-12 ml-1 flex-none inline-flex items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+                id="mobile-menu-open"
                 data-action="mobile-menu#toggle"
               >
                 <span class="sr-only">Open Application Menu</span>

--- a/app/views/themes/light/layouts/_account.html.erb
+++ b/app/views/themes/light/layouts/_account.html.erb
@@ -9,8 +9,6 @@
       <div class="h-screen md:h-auto overflow-hidden md:rounded-lg flex shadow main-container"
         data-controller="mobile-menu"
         data-mobile-menu-hidden-class="hidden"
-        data-mobile-menu-show-event-name-value="mobile-menu:show"
-        data-mobile-menu-hide-event-name-value="mobile-menu:hide"
       >
 
         <% menu = capture do %>
@@ -60,55 +58,34 @@
           id="mobile-menu-backdrop"
         >
           <div class="fixed inset-0 flex z-40">
-            <div class="absolute inset-0"
+            <button
+              data-mobile-menu-target="revealable"
+              data-action="mobile-menu#close"
+            
+              data-transition-enter="transition-opacity ease-linear duration-200"
+              data-transition-enter-start="opacity-0"
+              data-transition-enter-end="opacity-100"
+              data-transition-leave="transition-opacity ease-linear duration-200"
+              data-transition-leave-start="opacity-100"
+              data-transition-leave-end="opacity-0"
+
+              class="hidden fixed inset-0" aria-hidden="true"
+            >
+              <div class="absolute inset-0 bg-light-gradient opacity-75"></div>
+            </button>
+            <div
               data-mobile-menu-target="revealable"
               
-              data-controller="reveal"
-              
-              data-action="mobile-menu:show->reveal#show mobile-menu:hide->reveal#hide  reveal:hidden->mobile-menu#finishClosing
-              reveal:shown->mobile-menu#finishOpening"
+              data-transition-enter="transition ease-in-out duration-200 transform"
+              data-transition-enter-start="-trandarkPrimary-x-full"
+              data-transition-enter-end="trandarkPrimary-x-0"
+              data-transition-leave="transition ease-in-out duration-200 transform"
+              data-transition-leave-start="trandarkPrimary-x-0"
+              data-transition-leave-end="-trandarkPrimary-x-full"
+
+              class="hidden relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-dark-gradient shadow-xl"
             >
-              <button
-                data-action="mobile-menu#close"
-              
-                hidden
-                data-reveal
-                data-transition
-                data-transition-enter="transition-opacity ease-linear duration-200"
-                data-transition-enter-start="opacity-0"
-                data-transition-enter-end="opacity-100"
-                data-transition-leave="transition-opacity ease-linear duration-200"
-                data-transition-leave-start="opacity-100"
-                data-transition-leave-end="opacity-0"
-  
-                class="fixed inset-0" aria-hidden="true"
-              >
-                <div class="absolute inset-0 bg-light-gradient opacity-75"></div>
-              </button>
-            </div>
-            <div class=""
-              data-mobile-menu-target="revealable"
-              
-              data-controller="reveal"
-              
-              data-action="mobile-menu:show->reveal#show mobile-menu:hide->reveal#hide  reveal:hidden->mobile-menu#finishClosing
-              reveal:shown->mobile-menu#finishOpening"
-            >
-              <div
-                hidden
-                data-reveal
-                data-transition
-                data-transition-enter="transition ease-in-out duration-200 transform"
-                data-transition-enter-start="-trandarkPrimary-x-full"
-                data-transition-enter-end="trandarkPrimary-x-0"
-                data-transition-leave="transition ease-in-out duration-200 transform"
-                data-transition-leave-start="trandarkPrimary-x-0"
-                data-transition-leave-end="-trandarkPrimary-x-full"
-  
-                class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-dark-gradient shadow-xl"
-              >
-                <%= menu %>
-              </div>
+              <%= menu %>
             </div>
             <div class="flex-shrink-0 w-14" aria-hidden="true"></div>
           </div>
@@ -123,7 +100,7 @@
         <div class="flex flex-col w-0 flex-1 overflow-y-auto bg-gray-100 dark:bg-darkPrimary-800 lg:border-l dark:border-gray-500">
           <main class="flex-1 relative z-0 focus:outline-none" tabindex="0">
             <div class="flex flex-row items-center shadow-sm electron-draggable">
-              <button class="mobile-menu-trigger lg:hidden h-12 w-12 ml-1 flex-none inline-flex items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+              <button class="lg:hidden h-12 w-12 ml-1 flex-none inline-flex items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
                 id="mobile-menu-open"
                 data-action="mobile-menu#open"
               >

--- a/app/views/themes/light/layouts/_account.html.erb
+++ b/app/views/themes/light/layouts/_account.html.erb
@@ -20,7 +20,7 @@
             <div class="lg:hidden absolute right-0">
               <button class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white dark:ring-transparent"
                 id="mobile-menu-close"
-                data-action="reveal#hide"
+                data-action="mobile-menu#close"
               >
                 <span class="sr-only">Close Application Menu</span>
                 <svg class="h-6 w-6 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
@@ -58,45 +58,57 @@
         <div class="lg:hidden hidden"
           data-mobile-menu-target="wrapper"
           id="mobile-menu-backdrop"
-
-          data-controller="reveal"
-          data-reveal-away-value="true"
-          data-reveal-hide-keys-value="escape"
-
-          data-action="mobile-menu:show->reveal#show mobile-menu:hide->reveal#hide mobile-menu-toggle->reveal#toggle reveal:hidden->mobile-menu#hideWrapper"
         >
           <div class="fixed inset-0 flex z-40">
-            <button
-              data-action="reveal#hide"
-
-              hidden
-              data-reveal
-              data-transition
-              data-transition-enter="transition-opacity ease-linear duration-200"
-              data-transition-enter-start="opacity-0"
-              data-transition-enter-end="opacity-100"
-              data-transition-leave="transition-opacity ease-linear duration-200"
-              data-transition-leave-start="opacity-100"
-              data-transition-leave-end="opacity-0"
-
-              class="fixed inset-0" aria-hidden="true"
+            <div class="absolute inset-0"
+              data-mobile-menu-target="revealable"
+              
+              data-controller="reveal"
+              
+              data-action="mobile-menu:show->reveal#show mobile-menu:hide->reveal#hide  reveal:hidden->mobile-menu#finishClosing
+              reveal:shown->mobile-menu#finishOpening"
             >
-              <div class="absolute inset-0 bg-light-gradient opacity-75"></div>
-            </button>
-            <div
-              hidden
-              data-reveal
-              data-transition
-              data-transition-enter="transition ease-in-out duration-200 transform"
-              data-transition-enter-start="-trandarkPrimary-x-full"
-              data-transition-enter-end="trandarkPrimary-x-0"
-              data-transition-leave="transition ease-in-out duration-200 transform"
-              data-transition-leave-start="trandarkPrimary-x-0"
-              data-transition-leave-end="-trandarkPrimary-x-full"
-
-              class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-dark-gradient shadow-xl"
+              <button
+                data-action="mobile-menu#close"
+              
+                hidden
+                data-reveal
+                data-transition
+                data-transition-enter="transition-opacity ease-linear duration-200"
+                data-transition-enter-start="opacity-0"
+                data-transition-enter-end="opacity-100"
+                data-transition-leave="transition-opacity ease-linear duration-200"
+                data-transition-leave-start="opacity-100"
+                data-transition-leave-end="opacity-0"
+  
+                class="fixed inset-0" aria-hidden="true"
+              >
+                <div class="absolute inset-0 bg-light-gradient opacity-75"></div>
+              </button>
+            </div>
+            <div class=""
+              data-mobile-menu-target="revealable"
+              
+              data-controller="reveal"
+              
+              data-action="mobile-menu:show->reveal#show mobile-menu:hide->reveal#hide  reveal:hidden->mobile-menu#finishClosing
+              reveal:shown->mobile-menu#finishOpening"
             >
-              <%= menu %>
+              <div
+                hidden
+                data-reveal
+                data-transition
+                data-transition-enter="transition ease-in-out duration-200 transform"
+                data-transition-enter-start="-trandarkPrimary-x-full"
+                data-transition-enter-end="trandarkPrimary-x-0"
+                data-transition-leave="transition ease-in-out duration-200 transform"
+                data-transition-leave-start="trandarkPrimary-x-0"
+                data-transition-leave-end="-trandarkPrimary-x-full"
+  
+                class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-dark-gradient shadow-xl"
+              >
+                <%= menu %>
+              </div>
             </div>
             <div class="flex-shrink-0 w-14" aria-hidden="true"></div>
           </div>
@@ -113,7 +125,7 @@
             <div class="flex flex-row items-center shadow-sm electron-draggable">
               <button class="mobile-menu-trigger lg:hidden h-12 w-12 ml-1 flex-none inline-flex items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
                 id="mobile-menu-open"
-                data-action="mobile-menu#toggle"
+                data-action="mobile-menu#open"
               >
                 <span class="sr-only">Open Application Menu</span>
                 <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-base/issues/63

See co-dependent PRs:
- https://github.com/bullet-train-co/bullet_train/pull/282
- https://github.com/bullet-train-co/bullet_train-base/pull/79

This PR covers changes to the HTML:

- [X] add unique `id`'s to elements targeted by tests
- [x] fix the HTML or JavaScript: class names, or Stimulus controllers invoked