### PR TITLE
Adjust error text color

### DIFF
--- a/app/views/themes/light/_alert.html.erb
+++ b/app/views/themes/light/_alert.html.erb
@@ -1,7 +1,7 @@
 <% color ||= 'yellow' %>
 
 <div class="rounded-md bg-<%= color %>-400 border border-<%= color %>-500 py-4 px-5 mb-3">
-  <h3 class="text-sm text-<%= color %>-600 text-<%= color %>-600 font-light">
+  <h3 class="text-sm text-<%= color %>-900 font-light">
     <%= yield %>
   </h3>
 </div>


### PR DESCRIPTION
Closes [bullet_train#277](https://github.com/bullet-train-co/bullet_train/issues/277)

## Details
Previously, we used to use `text-red-900`.
This is from https://github.com/bullet-train-co/bullet_train/commit/2d585afd914ef34803daed132bcbfe65addcd360

![Old Style](https://user-images.githubusercontent.com/10546292/178268473-3d1365a5-a902-42da-8570-34a89f3b2ad9.png)

We added our own custom value for `900` in `tailwind.light.config.js`, but it's not that different from what the [Tailwind docs](https://tailwindcss.com/docs/text-color) had (`rgb(127 29 29)` → `#7f1d1d`), so I just used the custom value.

Looks like this now:
![Current Style](https://user-images.githubusercontent.com/10546292/178268980-f73fa4bc-0e9f-441e-9c25-2edfd79a7443.png)
