### PR TITLE
Make Trix toolbar colors more proeminent

### DIFF
--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -179,8 +179,18 @@
     }
 
     trix-toolbar {
+      @apply opacity-50 !important;
+
+      &.visible {
+        @apply opacity-100 !important;
+      }
+
       .trix-button-group, .trix-button {
-        @apply border-darkPrimary-900 !important;
+        @apply border-darkPrimary-400 !important;
+      }
+
+      .trix-button:disabled::before {
+        @apply opacity-25;
       }
     }
 


### PR DESCRIPTION
Before:
![Screen Shot 2022-07-25 at 10 17 04 AM](https://user-images.githubusercontent.com/2695893/180786413-00c2e526-dad8-49c5-88a8-055130212e1f.png)
![Screen Shot 2022-07-25 at 10 17 09 AM](https://user-images.githubusercontent.com/2695893/180786406-8d2d0c75-8745-462f-a417-d47dc21ca1ac.png)

After:
![Screen Shot 2022-07-25 at 10 14 31 AM](https://user-images.githubusercontent.com/2695893/180786242-04e630c0-2941-482e-ac74-1808e8a5d71c.png)
![Screen Shot 2022-07-25 at 10 14 24 AM](https://user-images.githubusercontent.com/2695893/180786249-5fb6eb23-e89b-48d7-9f29-500742bbee7f.png)
