### PR TITLE
Extract main tasks to `Application` module

### DIFF
--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -1,8 +1,7 @@
 module BulletTrain
   module Themes
     module Application
-      def self.eject_theme(task_name, ejected_theme_name)
-        theme_name = task_name.split(":")[2]
+      def self.eject_theme(theme_name, ejected_theme_name)
         theme_parts = theme_name.humanize.split.map {|str| str.capitalize }
         constantized_theme = theme_parts.join
         humanized_theme = theme_parts.join(" ")
@@ -58,10 +57,7 @@ module BulletTrain
         puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
       end
 
-      def self.install_theme(task_name)
-        # Grab the theme name from the rake task, bullet_train:theme:light:install
-        theme_name = task_name.split(":")[2]
-
+      def self.install_theme(theme_name)
         # Grabs the current theme from
         # def current_theme
         #   :theme_name
@@ -93,9 +89,7 @@ module BulletTrain
         end
       end
 
-      def self.clean_theme(task_name, args)
-        theme_name = task_name.split(":")[2]
-
+      def self.clean_theme(theme_name, args)
         theme_base_path = `bundle show --paths bullet_train-themes-#{theme_name}`.chomp
         `find app/views/themes/#{args[:theme]} | grep html.erb`.lines.map(&:chomp).each do |path|
           _, file = path.split("app/views/themes/#{args[:theme]}/")

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -57,6 +57,73 @@ module BulletTrain
         puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
       end
 
+      def self.release_theme(original_theme_name, args)
+        if original_theme_name != "light"
+          puts "You can only release new themes based off of Bullet Train's Light theme. Please eject a new theme from there, and publish your gem once you've finished making changes.".red
+          exit 1
+        end
+
+        puts "Preparing to release your custom theme: ".blue + args[:theme_name]
+        puts ""
+        puts "Before we make a new Ruby gem for your theme, you'll have to set up a GitHub repository first.".blue
+        puts "Hit <Return> and we'll open a browser to GitHub where you can create a new repository.".blue
+        puts "Make sure you name the repository ".blue + "bullet_train-themes-#{args[:theme_name]}"
+        puts ""
+        puts "When you're done, copy the SSH path from the new repository and return here.".blue
+        ask "We'll ask you to paste it to us in the next step."
+        `#{Gem::Platform.local.os == "linux" ? "xdg-open" : "open"} https://github.com/new`
+
+        ssh_path = ask "OK, what was the SSH path? (It should look like `git@github.com:your-account/your-new-repo.git`.)"
+        puts ""
+        puts "Great, you're all set.".blue
+        puts "We'll take it from here, so sit back and enjoy the ride 🚄️".blue
+        puts ""
+        puts "Creating a Ruby gem for ".blue + "#{args[:theme_name]}..."
+
+        Dir.mkdir("local") unless Dir.exist?("./local")
+        if Dir.exist?("./local/bullet_train-themes-#{args[:theme_name]}")
+          raise "You already have a repository named `bullet_train-themes-#{args[:theme_name]}` in `./local`.\n" \
+            "Make sure you delete it first to create an entirely new gem."
+        end
+        `git clone git@github.com:bullet-train-co/bullet_train-themes-light.git ./local/bullet_train-themes-#{args[:theme_name]}`
+
+        custom_file_replacer = BulletTrain::Themes::Light::CustomThemeFileReplacer.new(args[:theme_name])
+        custom_file_replacer.replace_theme("light", args[:theme_name])
+
+        work_tree_flag = "--work-tree=local/bullet_train-themes-#{args[:theme_name]}"
+        git_dir_flag = "--git-dir=local/bullet_train-themes-#{args[:theme_name]}/.git"
+        path = "./local/bullet_train-themes-#{args[:theme_name]}"
+
+        # Set up the proper remote.
+        `git #{work_tree_flag} #{git_dir_flag} remote set-url origin #{ssh_path}`
+        `git #{work_tree_flag} #{git_dir_flag} add .`
+        `git #{work_tree_flag} #{git_dir_flag} commit -m "Add initial files"`
+
+        # Build the gem.
+        `(cd #{path} && gem build bullet_train-themes-#{args[:theme_name]}.gemspec)`
+        `git #{work_tree_flag} #{git_dir_flag} add .`
+        `git #{work_tree_flag} #{git_dir_flag} commit -m "Build gem"`
+
+        # Commit the deleted files on the main application.
+        `git add .`
+        `git commit -m "Remove #{args[:theme_name]} files from application"`
+
+        # Push the gem's source code, but not the last commit in the main application.
+        `git #{work_tree_flag} #{git_dir_flag} push -u origin main`
+
+        puts ""
+        puts ""
+        puts "You're all set! Copy and paste the following commands to publish your gem:".blue
+        puts "cd ./local/bullet_train-themes-#{args[:theme_name]}"
+        puts "gem push bullet_train-themes-#{args[:theme_name]}-1.0.gem && cd ../../"
+        puts ""
+        puts "You may have to wait for some time until the gem can be downloaded via the Gemfile.".blue
+        puts "After a few minutes, run the following command in your main application:".blue
+        puts "bundle add bullet_train-themes-#{args[:theme_name]}"
+        puts ""
+        puts "Then you'll be ready to use your custom gem in your Bullet Train application.".blue
+      end
+
       def self.install_theme(theme_name)
         # Grabs the current theme from
         # def current_theme
@@ -99,6 +166,11 @@ module BulletTrain
             `rm #{path}`
           end
         end
+      end
+
+      def self.ask(string)
+        puts string.blue
+        $stdin.gets.strip
       end
     end
   end

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -1,7 +1,7 @@
 module BulletTrain
   module Themes
     module Application
-      def eject_theme(task_name, ejected_theme_name)
+      def self.eject_theme(task_name, ejected_theme_name)
         theme_name = task_name.split(":")[2]
         theme_parts = theme_name.humanize.split.map {|str| str.capitalize }
         constantized_theme = theme_parts.join
@@ -58,7 +58,7 @@ module BulletTrain
         puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
       end
 
-      def install_theme(task_name)
+      def self.install_theme(task_name)
         # Grab the theme name from the rake task, bullet_train:theme:light:install
         theme_name = task_name.split(":")[2]
 

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -57,6 +57,41 @@ module BulletTrain
 
         puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
       end
+
+      def install_theme(task_name)
+        # Grab the theme name from the rake task, bullet_train:theme:light:install
+        theme_name = task_name.split(":")[2]
+
+        # Grabs the current theme from
+        # def current_theme
+        #   :theme_name
+        # end
+        current_theme_regexp = /(^    :)(.*)/
+        current_theme = nil
+
+        new_lines = []
+        [
+          "./app/helpers/application_helper.rb",
+          "./Procfile.dev",
+          "./package.json"
+        ].each do |file|
+          File.open(file, "r") do |f|
+            new_lines = f.readlines
+            new_lines = new_lines.map do |line|
+              # Make sure we get the current theme before trying to replace it in any of the files.
+              # We grab it from the first file in the array above.
+              current_theme = line.scan(current_theme_regexp).flatten.last if line.match?(current_theme_regexp)
+
+              line.gsub!(/#{current_theme}/, theme_name) unless current_theme.nil?
+              line
+            end
+          end
+
+          File.open(file, "w") do |f|
+            f.puts new_lines.join
+          end
+        end
+      end
     end
   end
 end

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -92,6 +92,20 @@ module BulletTrain
           end
         end
       end
+
+      def self.clean_theme(task_name, args)
+        theme_name = task_name.split(":")[2]
+
+        theme_base_path = `bundle show --paths bullet_train-themes-#{theme_name}`.chomp
+        `find app/views/themes/#{args[:theme]} | grep html.erb`.lines.map(&:chomp).each do |path|
+          _, file = path.split("app/views/themes/#{args[:theme]}/")
+          original_theme_path = "#{theme_base_path}/app/views/themes/#{theme_name}/#{file}"
+          if File.read(path) == File.read(original_theme_path)
+            puts "No changes in \`#{path}\` since being ejected. Removing."
+            `rm #{path}`
+          end
+        end
+      end
     end
   end
 end

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -1,0 +1,62 @@
+module BulletTrain
+  module Themes
+    module Application
+      def eject_theme(task_name, ejected_theme_name)
+        theme_name = task_name.split(":")[2]
+        theme_parts = theme_name.humanize.split.map {|str| str.capitalize }
+        constantized_theme = theme_parts.join
+        humanized_theme = theme_parts.join(" ")
+        humanized_ejected_theme = ejected_theme_name.humanize.split.map {|str| str.capitalize }.join(" ")
+
+        theme_base_path = `bundle show --paths bullet_train-themes-#{theme_name}`.chomp
+        puts "Ejecting from #{humanized_theme} theme in `#{theme_base_path}`."
+
+        puts "Ejecting Tailwind configuration into `./tailwind.#{ejected_theme_name}.config.js`."
+        `cp #{theme_base_path}/tailwind.#{theme_name}.config.js #{Rails.root}/tailwind.#{ejected_theme_name}.config.js`
+
+        puts "Ejecting Tailwind mailer configuration into `./tailwind.mailer.#{ejected_theme_name}.config.js`."
+        `cp #{theme_base_path}/tailwind.mailer.#{theme_name}.config.js #{Rails.root}/tailwind.mailer.#{ejected_theme_name}.config.js`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/tailwind.mailer.#{ejected_theme_name}.config.js`
+
+        puts "Ejecting stylesheets into `./app/assets/stylesheets/#{ejected_theme_name}`."
+        `mkdir #{Rails.root}/app/assets/stylesheets`
+        `cp -R #{theme_base_path}/app/assets/stylesheets/#{theme_name} #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}`
+        `cp -R #{theme_base_path}/app/assets/stylesheets/#{theme_name}.tailwind.css #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}.tailwind.css`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{ejected_theme_name}/g" #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}.tailwind.css`
+
+        puts "Ejecting JavaScript into `./app/javascript/application.#{ejected_theme_name}.js`."
+        `cp #{theme_base_path}/app/javascript/application.#{theme_name}.js #{Rails.root}/app/javascript/application.#{ejected_theme_name}.js`
+
+        puts "Ejecting all theme partials into `./app/views/themes/#{ejected_theme_name}`."
+        `mkdir #{Rails.root}/app/views/themes`
+        `cp -R #{theme_base_path}/app/views/themes/#{theme_name} #{Rails.root}/app/views/themes/#{ejected_theme_name}`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/app/views/themes/#{ejected_theme_name}/layouts/_head.html.erb`
+
+        puts "Cutting local `Procfile.dev` over from `#{theme_name}` to `#{ejected_theme_name}`."
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/Procfile.dev`
+
+        puts "Cutting local `package.json` over from `#{theme_name}` to `#{ejected_theme_name}`."
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/package.json`
+
+        # Stub out the class that represents this theme and establishes its inheritance structure.
+        target_path = "#{Rails.root}/app/lib/bullet_train/themes/#{ejected_theme_name}.rb"
+        puts "Stubbing out a class that represents this theme in `.#{target_path}`."
+        `mkdir -p #{Rails.root}/app/lib/bullet_train/themes`
+        `cp #{theme_base_path}/lib/bullet_train/themes/#{theme_name}.rb #{target_path}`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/module #{constantized_theme}/module #{ejected_theme_name.titlecase}/g" #{target_path}`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/TailwindCss/#{constantized_theme}/g" #{target_path}`
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{target_path}`
+        ["require", "TODO", "mattr_accessor"].each do |thing_to_remove|
+          `grep -v #{thing_to_remove} #{target_path} > #{target_path}.tmp`
+          `mv #{target_path}.tmp #{target_path}`
+        end
+        `standardrb --fix #{target_path}`
+
+        puts "Cutting local project over from `#{theme_name}` to `#{ejected_theme_name}` in `app/helpers/application_helper.rb`."
+        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/:#{theme_name}/:#{ejected_theme_name}/g" #{Rails.root}/app/helpers/application_helper.rb`
+
+        puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
+      end
+    end
+  end
+end

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -120,6 +120,7 @@ module BulletTrain
         puts "You may have to wait for some time until the gem can be downloaded via the Gemfile.".blue
         puts "After a few minutes, run the following command in your main application:".blue
         puts "bundle add bullet_train-themes-#{args[:theme_name]}"
+        puts "rake bullet_train:themes:#{args[:theme_name]}:install"
         puts ""
         puts "Then you'll be ready to use your custom gem in your Bullet Train application.".blue
       end

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -2,10 +2,9 @@ module BulletTrain
   module Themes
     module Application
       def self.eject_theme(theme_name, ejected_theme_name)
-        theme_parts = theme_name.humanize.split.map {|str| str.capitalize }
+        theme_parts = theme_name.humanize.split.map { |str| str.capitalize }
         constantized_theme = theme_parts.join
         humanized_theme = theme_parts.join(" ")
-        humanized_ejected_theme = ejected_theme_name.humanize.split.map {|str| str.capitalize }.join(" ")
 
         theme_base_path = `bundle show --paths bullet_train-themes-#{theme_name}`.chomp
         puts "Ejecting from #{humanized_theme} theme in `#{theme_base_path}`."
@@ -15,13 +14,13 @@ module BulletTrain
 
         puts "Ejecting Tailwind mailer configuration into `./tailwind.mailer.#{ejected_theme_name}.config.js`."
         `cp #{theme_base_path}/tailwind.mailer.#{theme_name}.config.js #{Rails.root}/tailwind.mailer.#{ejected_theme_name}.config.js`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/tailwind.mailer.#{ejected_theme_name}.config.js`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/tailwind.mailer.#{ejected_theme_name}.config.js)
 
         puts "Ejecting stylesheets into `./app/assets/stylesheets/#{ejected_theme_name}`."
         `mkdir #{Rails.root}/app/assets/stylesheets`
         `cp -R #{theme_base_path}/app/assets/stylesheets/#{theme_name} #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}`
         `cp -R #{theme_base_path}/app/assets/stylesheets/#{theme_name}.tailwind.css #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}.tailwind.css`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{ejected_theme_name}/g" #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}.tailwind.css`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{ejected_theme_name}/g" #{Rails.root}/app/assets/stylesheets/#{ejected_theme_name}.tailwind.css)
 
         puts "Ejecting JavaScript into `./app/javascript/application.#{ejected_theme_name}.js`."
         `cp #{theme_base_path}/app/javascript/application.#{theme_name}.js #{Rails.root}/app/javascript/application.#{ejected_theme_name}.js`
@@ -29,22 +28,22 @@ module BulletTrain
         puts "Ejecting all theme partials into `./app/views/themes/#{ejected_theme_name}`."
         `mkdir #{Rails.root}/app/views/themes`
         `cp -R #{theme_base_path}/app/views/themes/#{theme_name} #{Rails.root}/app/views/themes/#{ejected_theme_name}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/app/views/themes/#{ejected_theme_name}/layouts/_head.html.erb`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/app/views/themes/#{ejected_theme_name}/layouts/_head.html.erb)
 
         puts "Cutting local `Procfile.dev` over from `#{theme_name}` to `#{ejected_theme_name}`."
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/Procfile.dev`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/Procfile.dev)
 
         puts "Cutting local `package.json` over from `#{theme_name}` to `#{ejected_theme_name}`."
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/package.json`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/package.json)
 
         # Stub out the class that represents this theme and establishes its inheritance structure.
         target_path = "#{Rails.root}/app/lib/bullet_train/themes/#{ejected_theme_name}.rb"
         puts "Stubbing out a class that represents this theme in `.#{target_path}`."
         `mkdir -p #{Rails.root}/app/lib/bullet_train/themes`
         `cp #{theme_base_path}/lib/bullet_train/themes/#{theme_name}.rb #{target_path}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/module #{constantized_theme}/module #{ejected_theme_name.titlecase}/g" #{target_path}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/TailwindCss/#{constantized_theme}/g" #{target_path}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{target_path}`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/module #{constantized_theme}/module #{ejected_theme_name.titlecase}/g" #{target_path})
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/TailwindCss/#{constantized_theme}/g" #{target_path})
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{target_path})
         ["require", "TODO", "mattr_accessor"].each do |thing_to_remove|
           `grep -v #{thing_to_remove} #{target_path} > #{target_path}.tmp`
           `mv #{target_path}.tmp #{target_path}`
@@ -52,7 +51,7 @@ module BulletTrain
         `standardrb --fix #{target_path}`
 
         puts "Cutting local project over from `#{theme_name}` to `#{ejected_theme_name}` in `app/helpers/application_helper.rb`."
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/:#{theme_name}/:#{ejected_theme_name}/g" #{Rails.root}/app/helpers/application_helper.rb`
+        %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/:#{theme_name}/:#{ejected_theme_name}/g" #{Rails.root}/app/helpers/application_helper.rb)
 
         puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
       end

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -10,75 +10,12 @@ namespace :bullet_train do
 
       desc "Publish your custom theme theme as a Ruby gem."
       task :release, [:theme_name] => :environment do |task, args|
-        puts "Preparing to release your custom theme: ".blue + args[:theme_name]
-        puts ""
-        puts "Before we make a new Ruby gem for your theme, you'll have to set up a GitHub repository first.".blue
-        puts "Hit <Return> and we'll open a browser to GitHub where you can create a new repository.".blue
-        puts "Make sure you name the repository ".blue + "bullet_train-themes-#{args[:theme_name]}"
-        puts ""
-        puts "When you're done, copy the SSH path from the new repository and return here.".blue
-        ask "We'll ask you to paste it to us in the next step."
-        `#{Gem::Platform.local.os == "linux" ? "xdg-open" : "open"} https://github.com/new`
-
-        ssh_path = ask "OK, what was the SSH path? (It should look like `git@github.com:your-account/your-new-repo.git`.)"
-        puts ""
-        puts "Great, you're all set.".blue
-        puts "We'll take it from here, so sit back and enjoy the ride 🚄️".blue
-        puts ""
-        puts "Creating a Ruby gem for ".blue + "#{args[:theme_name]}..."
-
-        Dir.mkdir("local") unless Dir.exist?("./local")
-        if Dir.exist?("./local/bullet_train-themes-#{args[:theme_name]}")
-          raise "You already have a repository named `bullet_train-themes-#{args[:theme_name]}` in `./local`.\n" \
-            "Make sure you delete it first to create an entirely new gem."
-        end
-        `git clone git@github.com:bullet-train-co/bullet_train-themes-light.git ./local/bullet_train-themes-#{args[:theme_name]}`
-
-        custom_file_replacer = BulletTrain::Themes::Light::CustomThemeFileReplacer.new(args[:theme_name])
-        custom_file_replacer.replace_theme("light", args[:theme_name])
-
-        work_tree_flag = "--work-tree=local/bullet_train-themes-#{args[:theme_name]}"
-        git_dir_flag = "--git-dir=local/bullet_train-themes-#{args[:theme_name]}/.git"
-        path = "./local/bullet_train-themes-#{args[:theme_name]}"
-
-        # Set up the proper remote.
-        `git #{work_tree_flag} #{git_dir_flag} remote set-url origin #{ssh_path}`
-        `git #{work_tree_flag} #{git_dir_flag} add .`
-        `git #{work_tree_flag} #{git_dir_flag} commit -m "Add initial files"`
-
-        # Build the gem.
-        `(cd #{path} && gem build bullet_train-themes-#{args[:theme_name]}.gemspec)`
-        `git #{work_tree_flag} #{git_dir_flag} add .`
-        `git #{work_tree_flag} #{git_dir_flag} commit -m "Build gem"`
-
-        # Commit the deleted files on the main application.
-        `git add .`
-        `git commit -m "Remove #{args[:theme_name]} files from application"`
-
-        # Push the gem's source code, but not the last commit in the main application.
-        `git #{work_tree_flag} #{git_dir_flag} push -u origin main`
-
-        puts ""
-        puts ""
-        puts "You're all set! Copy and paste the following commands to publish your gem:".blue
-        puts "cd ./local/bullet_train-themes-#{args[:theme_name]}"
-        puts "gem push bullet_train-themes-#{args[:theme_name]}-1.0.gem && cd ../../"
-        puts ""
-        puts "You may have to wait for some time until the gem can be downloaded via the Gemfile.".blue
-        puts "After a few minutes, run the following command in your main application:".blue
-        puts "bundle add bullet_train-themes-#{args[:theme_name]}"
-        puts ""
-        puts "Then you'll be ready to use your custom gem in your Bullet Train application.".blue
+        BulletTrain::Themes::Application.release_theme(get_theme_name_from_task(task), args)
       end
 
       desc "Install this theme to your main application."
       task :install do |task|
         BulletTrain::Themes::Application.install_theme(get_theme_name_from_task(task))
-      end
-
-      def ask(string)
-        puts string.blue
-        $stdin.gets.strip
       end
 
       desc "List view partials in theme that haven't changed since ejection from \"Light\"."

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -1,12 +1,11 @@
 require 'tasks/application'
-include BulletTrain::Themes::Application
 
 namespace :bullet_train do
   namespace :themes do
     namespace :light do
       desc "Fork the \"Light\" theme into your local repository."
       task :eject, [:destination] => :environment do |task, args|
-        eject_theme(task.name, args[:destination])
+        BulletTrain::Themes::Application.eject_theme(task.name, args[:destination])
       end
 
       desc "Publish your custom theme theme as a Ruby gem."
@@ -74,7 +73,7 @@ namespace :bullet_train do
 
       desc "Install this theme to your main application."
       task :install do |task|
-        install_theme(task.name)
+        BulletTrain::Themes::Application.install_theme(task.name)
       end
 
       def ask(string)

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -73,39 +73,8 @@ namespace :bullet_train do
       end
 
       desc "Install this theme to your main application."
-      task :install do |rake_task|
-        # Grab the theme name from the rake task, bullet_train:theme:light:install
-        theme_name = rake_task.name.split(":")[2]
-
-        # Grabs the current theme from
-        # def current_theme
-        #   :theme_name
-        # end
-        current_theme_regexp = /(^    :)(.*)/
-        current_theme = nil
-
-        new_lines = []
-        [
-          "./app/helpers/application_helper.rb",
-          "./Procfile.dev",
-          "./package.json"
-        ].each do |file|
-          File.open(file, "r") do |f|
-            new_lines = f.readlines
-            new_lines = new_lines.map do |line|
-              # Make sure we get the current theme before trying to replace it in any of the files.
-              # We grab it from the first file in the array above.
-              current_theme = line.scan(current_theme_regexp).flatten.last if line.match?(current_theme_regexp)
-
-              line.gsub!(/#{current_theme}/, theme_name) unless current_theme.nil?
-              line
-            end
-          end
-
-          File.open(file, "w") do |f|
-            f.puts new_lines.join
-          end
-        end
+      task :install do |task|
+        install_theme(task.name)
       end
 
       def ask(string)

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -1,56 +1,12 @@
+require 'tasks/application'
+include BulletTrain::Themes::Application
+
 namespace :bullet_train do
   namespace :themes do
     namespace :light do
       desc "Fork the \"Light\" theme into your local repository."
       task :eject, [:destination] => :environment do |task, args|
-        theme_base_path = `bundle show --paths bullet_train-themes-light`.chomp
-        puts "Ejecting from Light theme in `#{theme_base_path}`."
-
-        puts "Ejecting Tailwind configuration into `./tailwind.#{args[:destination]}.config.js`."
-        `cp #{theme_base_path}/tailwind.light.config.js #{Rails.root}/tailwind.#{args[:destination]}.config.js`
-
-        puts "Ejecting Tailwind mailer configuration into `./tailwind.mailer.#{args[:destination]}.config.js`."
-        `cp #{theme_base_path}/tailwind.mailer.light.config.js #{Rails.root}/tailwind.mailer.#{args[:destination]}.config.js`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{Rails.root}/tailwind.mailer.#{args[:destination]}.config.js`
-
-        puts "Ejecting stylesheets into `./app/assets/stylesheets/#{args[:destination]}`."
-        `mkdir #{Rails.root}/app/assets/stylesheets`
-        `cp -R #{theme_base_path}/app/assets/stylesheets/light #{Rails.root}/app/assets/stylesheets/#{args[:destination]}`
-        `cp -R #{theme_base_path}/app/assets/stylesheets/light.tailwind.css #{Rails.root}/app/assets/stylesheets/#{args[:destination]}.tailwind.css`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{Rails.root}/app/assets/stylesheets/#{args[:destination]}.tailwind.css`
-
-        puts "Ejecting JavaScript into `./app/javascript/application.#{args[:destination]}.js`."
-        `cp #{theme_base_path}/app/javascript/application.light.js #{Rails.root}/app/javascript/application.#{args[:destination]}.js`
-
-        puts "Ejecting all theme partials into `./app/views/themes/#{args[:destination]}`."
-        `mkdir #{Rails.root}/app/views/themes`
-        `cp -R #{theme_base_path}/app/views/themes/light #{Rails.root}/app/views/themes/#{args[:destination]}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{Rails.root}/app/views/themes/#{args[:destination]}/layouts/_head.html.erb`
-
-        puts "Cutting local `Procfile.dev` over from `light` to `#{args[:destination]}`."
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{Rails.root}/Procfile.dev`
-
-        puts "Cutting local `package.json` over from `light` to `#{args[:destination]}`."
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{Rails.root}/package.json`
-
-        # Stub out the class that represents this theme and establishes its inheritance structure.
-        target_path = "#{Rails.root}/app/lib/bullet_train/themes/#{args[:destination]}.rb"
-        puts "Stubbing out a class that represents this theme in `.#{target_path}`."
-        `mkdir -p #{Rails.root}/app/lib/bullet_train/themes`
-        `cp #{theme_base_path}/lib/bullet_train/themes/light.rb #{target_path}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/module Light/module #{args[:destination].titlecase}/g" #{target_path}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/TailwindCss/Light/g" #{target_path}`
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/light/#{args[:destination]}/g" #{target_path}`
-        ["require", "TODO", "mattr_accessor"].each do |thing_to_remove|
-          `grep -v #{thing_to_remove} #{target_path} > #{target_path}.tmp`
-          `mv #{target_path}.tmp #{target_path}`
-        end
-        `standardrb --fix #{target_path}`
-
-        puts "Cutting local project over from `light` to `#{args[:destination]}` in `app/helpers/application_helper.rb`."
-        `sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/:light/:#{args[:destination]}/g" #{Rails.root}/app/helpers/application_helper.rb`
-
-        puts "You must restart `bin/dev` at this point, because of the changes to `Procfile.dev` and `package.json`."
+        eject_theme(task.name, args[:destination])
       end
 
       desc "Publish your custom theme theme as a Ruby gem."

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -83,15 +83,7 @@ namespace :bullet_train do
 
       desc "List view partials in theme that haven't changed since ejection from \"Light\"."
       task :clean, [:theme] => :environment do |task, args|
-        theme_base_path = `bundle show --paths bullet_train-themes-light`.chomp
-        `find app/views/themes/#{args[:theme]} | grep html.erb`.lines.map(&:chomp).each do |path|
-          _, file = path.split("app/views/themes/#{args[:theme]}/")
-          light_path = "#{theme_base_path}/app/views/themes/light/#{file}"
-          if File.read(path) == File.read(light_path)
-            puts "No changes in \`#{path}\` since being ejected. Removing."
-            `rm #{path}`
-          end
-        end
+        BulletTrain::Themes::Application.clean_theme(task.name, args)
       end
     end
   end

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -1,4 +1,4 @@
-require 'tasks/application'
+require "tasks/application"
 
 namespace :bullet_train do
   namespace :themes do

--- a/lib/tasks/bullet_train/themes/light_tasks.rake
+++ b/lib/tasks/bullet_train/themes/light_tasks.rake
@@ -5,7 +5,7 @@ namespace :bullet_train do
     namespace :light do
       desc "Fork the \"Light\" theme into your local repository."
       task :eject, [:destination] => :environment do |task, args|
-        BulletTrain::Themes::Application.eject_theme(task.name, args[:destination])
+        BulletTrain::Themes::Application.eject_theme(get_theme_name_from_task(task), args[:destination])
       end
 
       desc "Publish your custom theme theme as a Ruby gem."
@@ -73,7 +73,7 @@ namespace :bullet_train do
 
       desc "Install this theme to your main application."
       task :install do |task|
-        BulletTrain::Themes::Application.install_theme(task.name)
+        BulletTrain::Themes::Application.install_theme(get_theme_name_from_task(task))
       end
 
       def ask(string)
@@ -83,7 +83,12 @@ namespace :bullet_train do
 
       desc "List view partials in theme that haven't changed since ejection from \"Light\"."
       task :clean, [:theme] => :environment do |task, args|
-        BulletTrain::Themes::Application.clean_theme(task.name, args)
+        BulletTrain::Themes::Application.clean_theme(get_theme_name_from_task(task), args)
+      end
+
+      # Grabs the theme name from task, i.e. - bullet_train:theme:light:eject.
+      def get_theme_name_from_task(task)
+        task.name.split(":")[2]
       end
     end
   end


### PR DESCRIPTION
Closes #40.

With this module in place, all of the theme names are declared dynamically so we don't have to edit much when we go to release a new gem, just a couple of rake task descriptions and the namespace inside the task file itself.

For lack of a better name I named this module `Application` directly namespaced under `BulletTrain::Themes`, but if we want to name it something else I'm open to other options.
