### PR TITLE
Only generate help text html element when help text is present

### DIFF
--- a/app/views/themes/light/fields/_field.html.erb
+++ b/app/views/themes/light/fields/_field.html.erb
@@ -64,7 +64,7 @@ end
   <% end %>
 
   <% # any help text. %>
-  <% if content_for?(:help) || other_options[:help] || content_for?(:after_help) %>
+  <% if content_for?(:help) || other_options[:help].present? || content_for?(:after_help) %>
     <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
       <%= yield :help %>
       <% flush_content_for :help %>


### PR DESCRIPTION
Closes #37.
Reported by @scottharvey.

I used the solution he provided in the issue.
Thanks for reporting!
