### PR TITLE
Update side menu color in dark mode

### DIFF
--- a/app/views/themes/light/layouts/_account.html.erb
+++ b/app/views/themes/light/layouts/_account.html.erb
@@ -92,7 +92,7 @@
               data-transition-leave-start="trandarkPrimary-x-0"
               data-transition-leave-end="-trandarkPrimary-x-full"
 
-              class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-dark-gradient shadow-xl"
+              class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-darkPrimary-800 shadow-xl"
             >
               <%= menu %>
             </div>


### PR DESCRIPTION
Since `bg-dark-gradient` got changed to `bg-dark-blue-gradient` in https://github.com/bullet-train-co/bullet_train-themes-light/commit/cddac6783cd94070e533116c63b63af0bac5e6fa, the side menu in dark mode was the same color as when it's in light mode.

I thought changing it to `darkPrimary-800` looked nice
![Screenshot from 2022-08-22 17-49-30](https://user-images.githubusercontent.com/10546292/185880275-5be9b1aa-3050-430b-b0dc-740ea3f1ba96.png)

I'm impartial to what color we use though.
