### PR TITLE
Add dark gradient background for dark mode

### DIFF
--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -14,6 +14,10 @@
       }
     }
 
+    .bg-dark-gradient {
+      background-image: linear-gradient(to bottom, var(--dark-primary-700), var(--dark-primary-800) 100%);
+    }
+
     /**
      * General
      **/

--- a/app/views/themes/light/layouts/_account.html.erb
+++ b/app/views/themes/light/layouts/_account.html.erb
@@ -83,7 +83,7 @@
               data-transition-leave-start="trandarkPrimary-x-0"
               data-transition-leave-end="-trandarkPrimary-x-full"
 
-              class="hidden relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-darkPrimary-800 shadow-xl"
+              class="hidden relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-dark-gradient shadow-xl"
             >
               <%= menu %>
             </div>


### PR DESCRIPTION
Closes #52.

I added `bg-darkPrimary-800` in https://github.com/bullet-train-co/bullet_train-themes-light/commit/ad19cb6083a970d22d2ff96e60feb7475970decc which set the dark mobile menu to the right color, but it broke the light menu color.

Simply adding `dark:bg-darkPrimary-800` didn't change the color, so I added a new `bg-dark-gradient` to the `dark-mode` stylesheet and set the class in the view back to `bg-dark-gradient`.


https://user-images.githubusercontent.com/10546292/189466389-40dfc6f9-f611-4bd1-9610-a5c49ce3c7c4.mov
