### PR TITLE
Error applying @button style to pagy-nav

### DIFF
--- a/app/assets/stylesheets/light/tailwind/components.css
+++ b/app/assets/stylesheets/light/tailwind/components.css
@@ -178,6 +178,10 @@
 
   .pagy-nav .page.active,
   .pagy-nav-js .page.active {
-    @apply button;
+     @apply shadow-sm text-white hover:text-white bg-primary-500 hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-600 hover:no-underline;
+
+    &.button-red {
+      @apply bg-red-500 hover:bg-red-600 focus:ring-red-600;
+    }
   }
 }


### PR DESCRIPTION
In the Discord chat someone reported having this CSS build issue.

<img width="1213" alt="Screen Shot 2022-10-14 at 09 14 46" src="https://user-images.githubusercontent.com/78157/195746484-44d335d3-1567-4cd6-815a-eda98f7dc3e6.png">

If you look in your browser CSS warnings you might also see something like this.

<img width="1211" alt="Screen Shot 2022-10-14 at 09 12 29" src="https://user-images.githubusercontent.com/78157/195746549-6bfe0bea-8306-45bc-aef6-d0839dd00314.png">

The issue is in the generated file `app/assets/builds/application.light.css` where this CSS declaration is being added

<img width="378" alt="Screen Shot 2022-10-14 at 09 11 29" src="https://user-images.githubusercontent.com/78157/195746672-845011ff-09ab-431f-9bd7-949027b9f8f6.png">

That CSS declaration is coming from `app/assets/stylesheets/light/tailwind/components.css` where we are trying to `@apply button` styles to the pagy navigation.

I'm not sure why `@apply button` is causing an issue but if I copy the styles from `.button` into the pagy navigation everything seems to work as expected.

I'm guessing there is something odd about the `.button` component but I couldn't find out what it was at first glance.
