### PR TITLE
Eject views from `base` gem and `tailwind_css` gem in rake task

### DIFF
--- a/lib/bullet_train/themes/light/custom_theme_file_replacer.rb
+++ b/lib/bullet_train/themes/light/custom_theme_file_replacer.rb
@@ -39,7 +39,7 @@ module BulletTrain
                 BulletTrain::Themes::Light::FileReplacer.replace_content(old: custom_gem_file[:file_name], new: main_app_file)
               end
             rescue Errno::ENOENT => _
-              puts "Skipping \`#{main_app_file}\` because it isn't present."
+              puts "Skipping `#{main_app_file}` because it isn't present."
             end
 
             # Only rename file names that still have the original theme in them, i.e. - ./tailwind.config.light.js

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -30,25 +30,6 @@ module BulletTrain
         `cp -R #{theme_base_path}/app/views/themes/#{theme_name} #{Rails.root}/app/views/themes/#{ejected_theme_name}`
         %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/app/views/themes/#{ejected_theme_name}/layouts/_head.html.erb)
 
-        # Eject files from `bullet_train-base`.
-        puts "Ejecting base theme templates into `app/views`"
-        bt_base_path = `bundle show --paths bullet_train`.chomp
-        bt_base_views = Dir.glob("#{bt_base_path}/app/views/**/*.html.erb")
-        views_to_ignore = [
-          "/app/views/bullet_train/partial_resolver.html.erb"
-        ]
-
-        bt_base_views.each do |view|
-          debased_view = view.gsub(bt_base_path, "")
-          next if views_to_ignore.include?(debased_view)
-
-          view_path = debased_view.split("/")
-          view_path.pop
-          dir_to_create = "#{Rails.root}#{view_path.join("/")}"
-          FileUtils.mkdir_p(dir_to_create) unless Dir.exist?(dir_to_create)
-          `cp -R #{bt_base_path}#{debased_view} #{Rails.root}#{debased_view}`
-        end
-
         # Eject files from `bullet_train-themes-tailwind_css`.
         puts "Ejecting Tailwind CSS templates into `app/views/themes/tailwind_css/`."
         tailwind_css_path = `bundle show --paths bullet_train-themes-tailwind_css`.chomp

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -30,6 +30,30 @@ module BulletTrain
         `cp -R #{theme_base_path}/app/views/themes/#{theme_name} #{Rails.root}/app/views/themes/#{ejected_theme_name}`
         %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/app/views/themes/#{ejected_theme_name}/layouts/_head.html.erb)
 
+        # Eject files from `bullet_train-base`.
+        puts "Ejecting base theme templates into `app/views`"
+        bt_base_path = `bundle show --paths bullet_train`.chomp
+        bt_base_views = Dir.glob("#{bt_base_path}/app/views/**/*.html.erb")
+        views_to_ignore = [
+          "/app/views/bullet_train/partial_resolver.html.erb"
+        ]
+
+        bt_base_views.each do |view|
+          debased_view = view.gsub(bt_base_path, "")
+          next if views_to_ignore.include?(debased_view)
+
+          view_path = debased_view.split("/")
+          view_path.pop
+          dir_to_create = "#{Rails.root}#{view_path.join("/")}"
+          FileUtils.mkdir_p(dir_to_create) unless Dir.exists?(dir_to_create)
+          `cp -R #{bt_base_path}#{debased_view} #{Rails.root}#{debased_view}`
+        end
+
+        # Eject files from `bullet_train-themes-tailwind_css`.
+        puts "Ejecting Tailwind CSS templates into `app/views/themes/tailwind_css/`."
+        tailwind_css_path = `bundle show --paths bullet_train-themes-tailwind_css`.chomp
+        `cp -R #{tailwind_css_path}/app/views/themes/tailwind_css #{Rails.root}/app/views/themes`
+
         puts "Cutting local `Procfile.dev` over from `#{theme_name}` to `#{ejected_theme_name}`."
         %x(sed -i #{'""' if `echo $OSTYPE`.include?("darwin")} "s/#{theme_name}/#{ejected_theme_name}/g" #{Rails.root}/Procfile.dev)
 

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -45,7 +45,7 @@ module BulletTrain
           view_path = debased_view.split("/")
           view_path.pop
           dir_to_create = "#{Rails.root}#{view_path.join("/")}"
-          FileUtils.mkdir_p(dir_to_create) unless Dir.exists?(dir_to_create)
+          FileUtils.mkdir_p(dir_to_create) unless Dir.exist?(dir_to_create)
           `cp -R #{bt_base_path}#{debased_view} #{Rails.root}#{debased_view}`
         end
 

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -78,7 +78,7 @@ module BulletTrain
         puts ""
         puts "When you're done, copy the SSH path from the new repository and return here.".blue
         ask "We'll ask you to paste it to us in the next step."
-        `#{Gem::Platform.local.os == "linux" ? "xdg-open" : "open"} https://github.com/new`
+        `#{(Gem::Platform.local.os == "linux") ? "xdg-open" : "open"} https://github.com/new`
 
         ssh_path = ask "OK, what was the SSH path? (It should look like `git@github.com:your-account/your-new-repo.git`.)"
         puts ""
@@ -170,7 +170,7 @@ module BulletTrain
           _, file = path.split("app/views/themes/#{args[:theme]}/")
           original_theme_path = "#{theme_base_path}/app/views/themes/#{theme_name}/#{file}"
           if File.read(path) == File.read(original_theme_path)
-            puts "No changes in \`#{path}\` since being ejected. Removing."
+            puts "No changes in `#{path}` since being ejected. Removing."
             `rm #{path}`
           end
         end


### PR DESCRIPTION
Closes #59.

## File structure
After adding these changes, views from `bullet_train-base` and `bullet_train-themes-tailwind_css` are applied in the following structure:
```
.
└── app/
    └── views/
        ├── ← All bullet_train-base views are here in their respective directories
        └── themes/
            ├── foo/
            └── tailwind_css
```

1. `bullet_train-base`: I decided to leave the folders as is instead of creating a `base` folder directly under `app/views/`. Once a developer does `git commit` they won't be able to tell what came from `base` unless they compare with the original repository, but I don't want to mess with the original structure, so I just placed the files as they appear in the original `bullet_train-base` repository.
2. `bullet_train-themes-tailwind_css`: I considered putting this under `app/views/themes/foo`, but for the same reason as 1, I went with the original structure and put the files under `app/views/themes/tailwind_css`.

Both unit tests and system tests are passing with this setup.

## All views, not just partials
#59 mentioned partials, but I'm assuming we want all the views, including ones that aren't partials as well. If this is incorrect, I can edit the code to just grab the partials.

## Add a flag for omitting base or tailwind_css views
Do we want to add a flag to ignore `base` and `tailwind_css` views when ejecting files?
